### PR TITLE
Add support for cmake-gui building (if Qt available and specified)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,26 @@
 # asdf-cmake [![Build Status](https://travis-ci.org/srivathsanmurali/asdf-cmake.svg?branch=master)](https://travis-ci.org/srivathsanmurali/asdf-cmake)
 
-CMake plugin for [asdf](https://github.com/asdf-vm/asdf) version manager 
+CMake plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
 
 ## Usage
 
 ### Install
+
 The plugin can be install using the following command.
 
 ```
 asdf plugin-add cmake https://github.com/srivathsanmurali/asdf-cmake.git
 asdf install cmake <version>
+```
+
+#### cmake-gui
+
+If you have Qt installed on your machine you can get the `cmake-gui` program built by providing the path to the Qt binary directory in the `QTBINDIR` environment variable when invoking `asdf install cmake`.
+
+For instance, on a Mac with Qt installed using `brew` that would be :
+
+```
+QTBINDIR=/usr/local/opt/qt/bin asdf install cmake <version>
 ```
 
 ### .tool-versions file

--- a/bin/install
+++ b/bin/install
@@ -26,10 +26,21 @@ install_cmake() {
 
     unzip -q $source_path -d $tmp_download_dir || exit 1
     cd $tmp_download_dir/CMake-${version}
-    ./bootstrap --prefix=$install_path
+    if [ -d "$QTBINDIR" ]; then
+      PATH=$PATH:$QTBINDIR ./bootstrap --prefix=$install_path --qt-gui
+    else
+      ./bootstrap --prefix=$install_path
+    fi
     make -j $concurrency
     make install
+
+    if [ -d "$install_path/CMake.app/Contents" ]; then
+      mkdir "$install_path/bin"
+      cd "$install_path/bin"
+      ln -s ../CMake.app/Contents/bin/* .
+    fi
   )
+
 }
 
 download_source_file() {


### PR DESCRIPTION
Done by adding the --qt-gui option to bootstrap if QTBINDIR is available.